### PR TITLE
Workaround for Windows VFAT Unicode bug

### DIFF
--- a/src/MusicSyncConverter/MusicSyncConverter/SyncService.cs
+++ b/src/MusicSyncConverter/MusicSyncConverter/SyncService.cs
@@ -321,6 +321,14 @@ namespace MusicSyncConverter
                 {
                     Console.WriteLine($"Delete {targetFileFull}");
                     File.Delete(targetFileFull);
+
+                    // if this happens, we most likely ran into a stupid Windows VFAT Unicode bug that points different filenames to the same or separate files depending on the operation.
+                    // https://twitter.com/patagona/status/1444626808935264261
+                    if (File.Exists(targetFileFull))
+                    {
+                        File.Delete(targetFileFull);
+                        Console.WriteLine($"Couldn't delete {targetFileFull} on the first try. This is probably due to a Windows bug related to VFAT (FAT32) handling. Re-Run sync to fix this.");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes issue where certain Unicode characters could cause files to not be properly synced if their names don't differ in ASCII/ANSI.

Example: `14 Don't Get Lost in Heaven.mp3` in source and `14 Don’t Get Lost in Heaven.mp3` would not cause the target file to be replaced as it should.