### PR TITLE
feat: Remove FFMpegCore

### DIFF
--- a/src/MusicSyncConverter/MusicSyncConverter/Conversion/Ffmpeg/FfProbeCodecType.cs
+++ b/src/MusicSyncConverter/MusicSyncConverter/Conversion/Ffmpeg/FfProbeCodecType.cs
@@ -1,0 +1,8 @@
+﻿namespace MusicSyncConverter.Conversion.Ffmpeg
+{
+    public class FfProbeCodecType
+    {
+        public const string Video = "video";
+        public const string Audio = "audio";
+    }
+}

--- a/src/MusicSyncConverter/MusicSyncConverter/Conversion/Ffmpeg/FfProbeFormat.cs
+++ b/src/MusicSyncConverter/MusicSyncConverter/Conversion/Ffmpeg/FfProbeFormat.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MusicSyncConverter.Conversion.Ffmpeg
+{
+    public class FfProbeFormat
+    {
+        [JsonPropertyName("format_name")]
+        public string? FormatName { get; set; }
+        [JsonPropertyName("tags")]
+        public IDictionary<string, string>? Tags { get; set; }
+    }
+}

--- a/src/MusicSyncConverter/MusicSyncConverter/Conversion/Ffmpeg/FfProbeResult.cs
+++ b/src/MusicSyncConverter/MusicSyncConverter/Conversion/Ffmpeg/FfProbeResult.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MusicSyncConverter.Conversion.Ffmpeg
+{
+    public class FfProbeResult
+    {
+        [JsonPropertyName("streams")]
+        public IList<FfProbeStream> Streams { get; set; } = null!;
+
+        [JsonPropertyName("format")]
+        public FfProbeFormat Format { get; set; } = null!;
+    }
+}

--- a/src/MusicSyncConverter/MusicSyncConverter/Conversion/Ffmpeg/FfProbeStream.cs
+++ b/src/MusicSyncConverter/MusicSyncConverter/Conversion/Ffmpeg/FfProbeStream.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MusicSyncConverter.Conversion.Ffmpeg
+{
+    public class FfProbeStream
+    {
+        [JsonPropertyName("codec_type")]
+        public string CodecType { get; set; } = null!;
+
+        [JsonPropertyName("codec_name")]
+        public string? CodecName { get; set; }
+
+        [JsonPropertyName("profile")]
+        public string? Profile { get; set; }
+
+        [JsonPropertyName("channels")]
+        public int? Channels { get; set; }
+
+        [JsonPropertyName("sample_rate")]
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+        public int? SampleRateHz { get; set; }
+
+        [JsonPropertyName("bit_rate")]
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+        public int BitRate { get; set; }
+
+        [JsonPropertyName("tags")]
+        public IDictionary<string, string>? Tags { get; set; }
+    }
+}

--- a/src/MusicSyncConverter/MusicSyncConverter/Conversion/MediaConverter.cs
+++ b/src/MusicSyncConverter/MusicSyncConverter/Conversion/MediaConverter.cs
@@ -356,7 +356,7 @@ namespace MusicSyncConverter.Conversion
 
             if (encoderInfo.Bitrate.HasValue)
             {
-                args.AddRange(new[] { "-b:a", encoderInfo.Bitrate.Value.ToString() });
+                args.AddRange(new[] { "-b:a", (encoderInfo.Bitrate.Value * 1000).ToString() });
             }
 
             if (tags != null)

--- a/src/MusicSyncConverter/MusicSyncConverter/MusicSyncConverter.csproj
+++ b/src/MusicSyncConverter/MusicSyncConverter/MusicSyncConverter.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FFMpegCore" Version="4.7.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="6.0.0" />

--- a/src/MusicSyncConverter/MusicSyncConverter/Tags/ITagReader.cs
+++ b/src/MusicSyncConverter/MusicSyncConverter/Tags/ITagReader.cs
@@ -1,4 +1,4 @@
-﻿using FFMpegCore;
+﻿using MusicSyncConverter.Conversion.Ffmpeg;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,7 +14,7 @@ namespace MusicSyncConverter.Tags
         /// <param name="fileName">the file itself</param>
         /// <param name="fileExtension">the file's original extension</param>
         /// <returns>the files' tags in Vorbis Comment format</returns>
-        Task<IReadOnlyList<KeyValuePair<string, string>>> GetTags(IMediaAnalysis mediaAnalysis, string fileName, string fileExtension, CancellationToken cancellationToken);
+        Task<IReadOnlyList<KeyValuePair<string, string>>> GetTags(FfProbeResult mediaAnalysis, string fileName, string fileExtension, CancellationToken cancellationToken);
         bool CanHandle(string fileName, string fileExtension);
     }
 }

--- a/src/MusicSyncConverter/MusicSyncConverter/Tags/VorbisCommentReaderWriterBase.cs
+++ b/src/MusicSyncConverter/MusicSyncConverter/Tags/VorbisCommentReaderWriterBase.cs
@@ -1,4 +1,4 @@
-﻿using FFMpegCore;
+﻿using MusicSyncConverter.Conversion.Ffmpeg;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -20,7 +20,7 @@ namespace MusicSyncConverter.Tags
             _tempFileSession = tempFileSession;
         }
 
-        public async Task<IReadOnlyList<KeyValuePair<string, string>>> GetTags(IMediaAnalysis mediaAnalysis, string fileName, string fileExtension, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<KeyValuePair<string, string>>> GetTags(FfProbeResult mediaAnalysis, string fileName, string fileExtension, CancellationToken cancellationToken)
         {
             var tagFile = _tempFileSession.GetTempFilePath();
             await ExportTags(tagFile, fileName, cancellationToken);


### PR DESCRIPTION
FFMpegCore is slow, the latest version doesn't work properly and it's unnecessarily complex for what it is (partly due to still targeting netstandard2.0)

this replaces all usages with own simple calls to Process.Start instead of FFMpegCore+Instances